### PR TITLE
Implementa a funcionalidade de compra de ativos 

### DIFF
--- a/OrangeJuiceBank/OrangeJuiceBank.API/Controllers/AssetsController.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.API/Controllers/AssetsController.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OrangeJuiceBank.API.Models;
+using OrangeJuiceBank.Domain.Repositories;
+
+namespace OrangeJuiceBank.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class AssetsController : ControllerBase
+    {
+        private readonly IAssetRepository _assetRepository;
+
+        public AssetsController(IAssetRepository assetRepository)
+        {
+            _assetRepository = assetRepository;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetAll()
+        {
+            var assets = await _assetRepository.GetAllAsync();
+
+            var result = assets.Select(a => new AssetResponse
+            {
+                Id = a.Id,
+                Name = a.Name,
+                Type = a.Type,
+                CurrentPrice = a.CurrentPrice
+            });
+
+            return Ok(result);
+        }
+    }
+}

--- a/OrangeJuiceBank/OrangeJuiceBank.API/Controllers/InvestmentController.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.API/Controllers/InvestmentController.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OrangeJuiceBank.Domain.Services;
+
+namespace OrangeJuiceBank.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class InvestmentController : ControllerBase
+    {
+        private readonly IInvestmentService _investmentService;
+
+        public InvestmentController(IInvestmentService investmentService)
+        {
+            _investmentService = investmentService;
+        }
+
+        [HttpPost("buy")]
+        public async Task<IActionResult> BuyAsset([FromBody] BuyAssetRequest request)
+        {
+            var userId = Guid.Parse(User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value!);
+
+            await _investmentService.BuyAssetAsync(userId, request.AccountId, request.AssetId, request.Quantity);
+
+            return Ok("Compra realizada com sucesso.");
+        }
+    }
+
+    public class BuyAssetRequest
+    {
+        public Guid AccountId { get; set; }
+        public Guid AssetId { get; set; }
+        public decimal Quantity { get; set; }
+    }
+}

--- a/OrangeJuiceBank/OrangeJuiceBank.API/Models/AssetResponse.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.API/Models/AssetResponse.cs
@@ -1,0 +1,12 @@
+﻿using OrangeJuiceBank.Domain;
+
+namespace OrangeJuiceBank.API.Models
+{
+    public class AssetResponse
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public AssetType Type { get; set; }
+        public decimal CurrentPrice { get; set; }
+    }
+}

--- a/OrangeJuiceBank/OrangeJuiceBank.API/Program.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.API/Program.cs
@@ -19,6 +19,8 @@ builder.Services.AddScoped<IAccountRepository, AccountRepository>();
 builder.Services.AddScoped<ITransactionRepository, TransactionRepository>();
 builder.Services.AddScoped<IAssetRepository, AssetRepository>();
 builder.Services.AddScoped<IInvestmentRepository, InvestmentRepository>();
+builder.Services.AddScoped<IInvestmentService, InvestmentService>();
+
 
 builder.Services.AddScoped<IAccountService, AccountService>();
 

--- a/OrangeJuiceBank/OrangeJuiceBank.Domain/Repositories/IAssetRepository.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.Domain/Repositories/IAssetRepository.cs
@@ -6,5 +6,7 @@ namespace OrangeJuiceBank.Domain.Repositories
     public interface IAssetRepository
     {
         Task<Asset> GetByIdAsync(Guid id);
+        Task<IEnumerable<Asset>> GetAllAsync();
+
     }
 }

--- a/OrangeJuiceBank/OrangeJuiceBank.Domain/Services/IInvestmentService.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.Domain/Services/IInvestmentService.cs
@@ -1,0 +1,7 @@
+﻿namespace OrangeJuiceBank.Domain.Services
+{
+    public interface IInvestmentService
+    {
+        Task BuyAssetAsync(Guid userId, Guid accountId, Guid assetId, decimal quantity);
+    }
+}

--- a/OrangeJuiceBank/OrangeJuiceBank.Infrastructure/Data/ApplicationDbContext.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.Infrastructure/Data/ApplicationDbContext.cs
@@ -65,6 +65,36 @@ namespace OrangeJuiceBank.Infrastructure.Data
             modelBuilder.Entity<Transaction>()
                 .Property(t => t.Amount)
                 .HasPrecision(18, 2);
+            modelBuilder.Entity<Asset>().HasData(
+                new Asset
+                {
+                    Id = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+                    Name = "Boi Bom",
+                    Type = AssetType.Acao,
+                    CurrentPrice = 25.50m
+                },
+                new Asset
+                {
+                    Id = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+                    Name = "NuvemCinza",
+                    Type = AssetType.Acao,
+                    CurrentPrice = 120.45m
+                },
+                new Asset
+                {
+                    Id = Guid.Parse("33333333-3333-3333-3333-333333333333"),
+                    Name = "CDB Banco A",
+                    Type = AssetType.Cdb,
+                    CurrentPrice = 1000.00m
+                },
+                 new Asset
+                 {
+                     Id = Guid.Parse("44444444-4444-4444-4444-444444444444"),
+                     Name = "Tesouro Selic 2025",
+                     Type = AssetType.TesouroDireto,
+                     CurrentPrice = 100.00m
+                 }
+            );
 
             base.OnModelCreating(modelBuilder);
         }

--- a/OrangeJuiceBank/OrangeJuiceBank.Infrastructure/Data/ApplicationDbContext.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.Infrastructure/Data/ApplicationDbContext.cs
@@ -65,6 +65,7 @@ namespace OrangeJuiceBank.Infrastructure.Data
             modelBuilder.Entity<Transaction>()
                 .Property(t => t.Amount)
                 .HasPrecision(18, 2);
+
             modelBuilder.Entity<Asset>().HasData(
                 new Asset
                 {

--- a/OrangeJuiceBank/OrangeJuiceBank.Infrastructure/Repositories/AssetRepository.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.Infrastructure/Repositories/AssetRepository.cs
@@ -17,5 +17,10 @@ namespace OrangeJuiceBank.Infrastructure.Repositories
         {
             return await _context.Assets.FirstOrDefaultAsync(a => a.Id == id);
         }
+        public async Task<IEnumerable<Asset>> GetAllAsync()
+        {
+            return await _context.Assets.ToListAsync();
+        }
+
     }
 }

--- a/OrangeJuiceBank/OrangeJuiceBank.Infrastructure/Services/InvestmentService.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.Infrastructure/Services/InvestmentService.cs
@@ -1,0 +1,95 @@
+﻿using OrangeJuiceBank.Domain;
+using OrangeJuiceBank.Domain.Repositories;
+using OrangeJuiceBank.Domain.Services;
+
+namespace OrangeJuiceBank.Infrastructure.Services
+{
+    public class InvestmentService : IInvestmentService
+    {
+        private readonly IAccountRepository _accountRepository;
+        private readonly IAssetRepository _assetRepository;
+        private readonly IInvestmentRepository _investmentRepository;
+        private readonly ITransactionRepository _transactionRepository;
+
+        public InvestmentService(
+            IAccountRepository accountRepository,
+            IAssetRepository assetRepository,
+            IInvestmentRepository investmentRepository,
+            ITransactionRepository transactionRepository)
+        {
+            _accountRepository = accountRepository;
+            _assetRepository = assetRepository;
+            _investmentRepository = investmentRepository;
+            _transactionRepository = transactionRepository;
+        }
+
+        public async Task BuyAssetAsync(Guid userId, Guid accountId, Guid assetId, decimal quantity)
+        {
+            if (quantity <= 0)
+                throw new InvalidOperationException("A quantidade deve ser positiva.");
+
+            var account = await _accountRepository.GetByIdAsync(accountId);
+            if (account == null)
+                throw new InvalidOperationException("Conta não encontrada.");
+
+            if (account.UserId != userId)
+                throw new InvalidOperationException("Conta não pertence ao usuário.");
+
+            if (account.Type != AccountType.Investimento)
+                throw new InvalidOperationException("Somente contas de investimento podem realizar compras de ativos.");
+
+            var asset = await _assetRepository.GetByIdAsync(assetId);
+            if (asset == null)
+                throw new InvalidOperationException("Ativo não encontrado.");
+
+            var totalPrice = quantity * asset.CurrentPrice;
+
+            // Validação de mínimo investimento
+            if (asset.Type == AssetType.Cdb && totalPrice < 1000)
+                throw new InvalidOperationException("Compra mínima para CDB é R$1000.");
+
+            if (asset.Type == AssetType.TesouroDireto && totalPrice < 100)
+                throw new InvalidOperationException("Compra mínima para Tesouro Direto é R$100.");
+
+            if (account.Balance < totalPrice)
+                throw new InvalidOperationException("Saldo insuficiente.");
+
+            account.Balance -= totalPrice;
+
+            var existingInvestment = account.Investments?.FirstOrDefault(i => i.AssetId == assetId);
+
+            if (existingInvestment != null)
+            {
+                var totalQuantity = existingInvestment.Quantity + quantity;
+                var totalInvested = (existingInvestment.Quantity * existingInvestment.AveragePrice) + totalPrice;
+                existingInvestment.Quantity = totalQuantity;
+                existingInvestment.AveragePrice = totalInvested / totalQuantity;
+            }
+            else
+            {
+                var investment = new Investment
+                {
+                    Id = Guid.NewGuid(),
+                    AccountId = accountId,
+                    AssetId = assetId,
+                    Quantity = quantity,
+                    AveragePrice = asset.CurrentPrice,
+                    CreatedAt = DateTime.UtcNow
+                };
+                await _investmentRepository.AddAsync(investment);
+            }
+
+            var transaction = new Transaction
+            {
+                Id = Guid.NewGuid(),
+                Type = TransactionType.CompraAtivo,
+                Amount = totalPrice,
+                Timestamp = DateTime.UtcNow,
+                SourceAccountId = accountId
+            };
+
+            await _transactionRepository.AddAsync(transaction);
+            await _accountRepository.UpdateAsync(account);
+        }
+    }
+}

--- a/OrangeJuiceBank/OrangeJuiceBank.Tests/InvestmentServiceTests.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.Tests/InvestmentServiceTests.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using OrangeJuiceBank.Domain;
+using OrangeJuiceBank.Domain.Repositories;
+using OrangeJuiceBank.Infrastructure.Services;
+using Xunit;
+
+namespace OrangeJuiceBank.Tests
+{
+    public class InvestmentServiceTests
+    {
+        private readonly Mock<IAccountRepository> _accountRepoMock = new();
+        private readonly Mock<IAssetRepository> _assetRepoMock = new();
+        private readonly Mock<IInvestmentRepository> _investmentRepoMock = new();
+        private readonly Mock<ITransactionRepository> _transactionRepoMock = new();
+
+        private InvestmentService CreateService() =>
+            new InvestmentService(
+                _accountRepoMock.Object,
+                _assetRepoMock.Object,
+                _investmentRepoMock.Object,
+                _transactionRepoMock.Object
+            );
+
+        [Fact]
+        public async Task BuyAsset_ShouldThrow_WhenAccountIsNotInvestment()
+        {
+            // Arrange
+            var account = new Account
+            {
+                Id = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                Type = AccountType.Corrente,
+                Balance = 1000
+            };
+
+            var asset = new Asset
+            {
+                Id = Guid.NewGuid(),
+                CurrentPrice = 10,
+                Type = AssetType.Acao
+            };
+
+            _accountRepoMock.Setup(r => r.GetByIdAsync(account.Id))
+                .ReturnsAsync(account);
+
+            _assetRepoMock.Setup(r => r.GetByIdAsync(asset.Id))
+                .ReturnsAsync(asset);
+
+            var service = CreateService();
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                service.BuyAssetAsync(account.UserId, account.Id, asset.Id, 1));
+
+            Assert.Equal("Somente contas de investimento podem realizar compras de ativos.", ex.Message);
+        }
+
+        [Fact]
+        public async Task BuyAsset_ShouldThrow_WhenBalanceIsInsufficient()
+        {
+            // Arrange
+            var account = new Account
+            {
+                Id = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                Type = AccountType.Investimento,
+                Balance = 5
+            };
+
+            var asset = new Asset
+            {
+                Id = Guid.NewGuid(),
+                CurrentPrice = 10,
+                Type = AssetType.Acao
+            };
+
+            _accountRepoMock.Setup(r => r.GetByIdAsync(account.Id))
+                .ReturnsAsync(account);
+
+            _assetRepoMock.Setup(r => r.GetByIdAsync(asset.Id))
+                .ReturnsAsync(asset);
+
+            var service = CreateService();
+
+            // Act & Assert
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                service.BuyAssetAsync(account.UserId, account.Id, asset.Id, 1));
+
+            Assert.Equal("Saldo insuficiente.", ex.Message);
+        }
+
+        [Fact]
+        public async Task BuyAsset_ShouldSucceed_WhenAccountIsInvestmentAndBalanceIsEnough()
+        {
+            // Arrange
+            var account = new Account
+            {
+                Id = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                Type = AccountType.Investimento,
+                Balance = 1000,
+                Investments = new List<Investment>()
+            };
+
+            var asset = new Asset
+            {
+                Id = Guid.NewGuid(),
+                CurrentPrice = 10,
+                Type = AssetType.Acao
+            };
+
+            _accountRepoMock.Setup(r => r.GetByIdAsync(account.Id))
+                .ReturnsAsync(account);
+
+            _assetRepoMock.Setup(r => r.GetByIdAsync(asset.Id))
+                .ReturnsAsync(asset);
+
+            _investmentRepoMock.Setup(r => r.AddAsync(It.IsAny<Investment>()))
+                .Returns(Task.CompletedTask);
+
+            _transactionRepoMock.Setup(r => r.AddAsync(It.IsAny<Transaction>()))
+                .Returns(Task.CompletedTask);
+
+            _accountRepoMock.Setup(r => r.UpdateAsync(account))
+                .Returns(Task.CompletedTask);
+
+            var service = CreateService();
+
+            // Act
+            await service.BuyAssetAsync(account.UserId, account.Id, asset.Id, 2);
+
+            // Assert
+            _investmentRepoMock.Verify(r => r.AddAsync(It.IsAny<Investment>()), Times.Once);
+            _transactionRepoMock.Verify(r => r.AddAsync(It.IsAny<Transaction>()), Times.Once);
+            _accountRepoMock.Verify(r => r.UpdateAsync(account), Times.Once);
+
+            Assert.Equal(980, account.Balance); // 1000 - (2*10)
+        }
+    }
+}


### PR DESCRIPTION
-  Criação do InvestmentController com endpoint POST /api/Investment/buy
- Implementação da regra de negócio que permite compra somente em contas do tipo Investimento
- Validação de saldo suficiente para realizar a compra
- Registro automático da transação e do investimento associado à conta
- Criação de testes unitários no InvestmentServiceTests cobrindo:
     - Compra bem-sucedida
     - Conta não sendo do tipo investimento
     -Saldo insuficiente