### PR TITLE
Compra e venda de ativos 

### DIFF
--- a/OrangeJuiceBank/OrangeJuiceBank.API/Controllers/InvestmentController.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.API/Controllers/InvestmentController.cs
@@ -25,6 +25,24 @@ namespace OrangeJuiceBank.API.Controllers
 
             return Ok("Compra realizada com sucesso.");
         }
+
+        [HttpPost("sell")]
+        public async Task<IActionResult> SellAsset([FromBody] SellAssetRequest request)
+        {
+            var userId = Guid.Parse(User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value!);
+
+            await _investmentService.SellAssetAsync(userId, request.AccountId, request.AssetId, request.Quantity);
+
+            return Ok("Venda realizada com sucesso.");
+        }
+
+        public class SellAssetRequest
+        {
+            public Guid AccountId { get; set; }
+            public Guid AssetId { get; set; }
+            public decimal Quantity { get; set; }
+        }
+
     }
 
     public class BuyAssetRequest

--- a/OrangeJuiceBank/OrangeJuiceBank.Domain/Repositories/IInvestmentRepository.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.Domain/Repositories/IInvestmentRepository.cs
@@ -4,5 +4,6 @@ namespace OrangeJuiceBank.Domain.Repositories
     public interface IInvestmentRepository
     {
         Task AddAsync(Investment investment);
+        Task RemoveAsync(Investment investment);
     }
 }

--- a/OrangeJuiceBank/OrangeJuiceBank.Domain/Services/IInvestmentService.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.Domain/Services/IInvestmentService.cs
@@ -3,5 +3,6 @@
     public interface IInvestmentService
     {
         Task BuyAssetAsync(Guid userId, Guid accountId, Guid assetId, decimal quantity);
+        Task SellAssetAsync(Guid userId, Guid accountId, Guid assetId, decimal quantity);
     }
 }

--- a/OrangeJuiceBank/OrangeJuiceBank.Infrastructure/Repositories/InvestmentRepository.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.Infrastructure/Repositories/InvestmentRepository.cs
@@ -17,5 +17,10 @@ namespace OrangeJuiceBank.Infrastructure.Repositories
             await _context.Investments.AddAsync(investment);
             await _context.SaveChangesAsync();
         }
+        public async Task RemoveAsync(Investment investment)
+        {
+            _context.Investments.Remove(investment);
+            await _context.SaveChangesAsync();
+        }
     }
 }

--- a/OrangeJuiceBank/OrangeJuiceBank.Tests/InvestmentControllerTests.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.Tests/InvestmentControllerTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+using OrangeJuiceBank.API.Controllers;
+using OrangeJuiceBank.Domain.Services;
+
+namespace OrangeJuiceBank.Tests
+{
+    public class InvestmentControllerTests
+    {
+        private readonly Mock<IInvestmentService> _investmentServiceMock;
+        private readonly InvestmentController _controller;
+
+        public InvestmentControllerTests()
+        {
+            _investmentServiceMock = new Mock<IInvestmentService>();
+            _controller = new InvestmentController(_investmentServiceMock.Object);
+
+            // Mock do usuário autenticado
+            var userId = Guid.NewGuid();
+            var claims = new[]
+            {
+                new System.Security.Claims.Claim(System.Security.Claims.ClaimTypes.NameIdentifier, userId.ToString())
+            };
+
+            var identity = new System.Security.Claims.ClaimsIdentity(claims, "TestAuth");
+            var principal = new System.Security.Claims.ClaimsPrincipal(identity);
+
+            _controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext { User = principal }
+            };
+        }
+
+        [Fact]
+        public async Task BuyAsset_ShouldReturnOk_WhenBuySucceeds()
+        {
+            // Arrange
+            var request = new BuyAssetRequest
+            {
+                AccountId = Guid.NewGuid(),
+                AssetId = Guid.NewGuid(),
+                Quantity = 10
+            };
+
+            // Act
+            var result = await _controller.BuyAsset(request);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal("Compra realizada com sucesso.", okResult.Value);
+
+            _investmentServiceMock.Verify(s =>
+                s.BuyAssetAsync(It.IsAny<Guid>(), request.AccountId, request.AssetId, request.Quantity),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task SellAsset_ShouldReturnOk_WhenSellSucceeds()
+        {
+            // Arrange
+            var request = new InvestmentController.SellAssetRequest
+            {
+                AccountId = Guid.NewGuid(),
+                AssetId = Guid.NewGuid(),
+                Quantity = 5
+            };
+
+            // Act
+            var result = await _controller.SellAsset(request);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal("Venda realizada com sucesso.", okResult.Value);
+
+            _investmentServiceMock.Verify(s =>
+                s.SellAssetAsync(It.IsAny<Guid>(), request.AccountId, request.AssetId, request.Quantity),
+                Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
Esta PR adiciona testes unitários ao InvestmentController, contemplando os seguintes cenários:

- Compra de ativos: valida se a compra é processada corretamente e retorna status 200 OK.
- Venda de ativos: valida se a venda é processada corretamente e retorna status 200 OK.
- 
Os testes utilizam Moq para simular o comportamento do serviço de investimentos (IInvestmentService), garantindo que os métodos BuyAssetAsync e SellAssetAsync sejam chamados conforme esperado.