### PR TITLE
Implementar filtro de data no extrato de transações da conta

### DIFF
--- a/OrangeJuiceBank/OrangeJuiceBank.API/Controllers/AccountController.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.API/Controllers/AccountController.cs
@@ -134,7 +134,9 @@ namespace OrangeJuiceBank.API.Controllers
         }
 
         [HttpGet("{id}/statement")]
-        public async Task<IActionResult> GetStatement(Guid id)
+        public async Task<IActionResult> GetStatement( Guid id,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to)
         {
             var userId = GetUserId();
             var account = await _accountService.GetAccountByIdAsync(id);
@@ -146,6 +148,12 @@ namespace OrangeJuiceBank.API.Controllers
 
             var transactions = await _transactionRepository.GetByAccountIdAsync(id);
 
+            if (from.HasValue)
+                transactions = transactions.Where(t => t.Timestamp >= from.Value).ToList();
+
+            if (to.HasValue)
+                transactions = transactions.Where(t => t.Timestamp <= to.Value).ToList();
+
             var result = transactions.Select(t => new TransactionResponse
             {
                 Id = t.Id,
@@ -156,8 +164,6 @@ namespace OrangeJuiceBank.API.Controllers
 
             return Ok(result);
         }
-
-        // Método helper para extrair o Guid do usuário logado
         private Guid GetUserId()
         {
             var userIdClaim = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;

--- a/OrangeJuiceBank/OrangeJuiceBank.Domain/Services/AccountService.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.Domain/Services/AccountService.cs
@@ -105,7 +105,7 @@ namespace OrangeJuiceBank.Infrastructure.Services
             await _accountRepository.UpdateAsync(destination);
         }
 
-        public async Task<Account> GetAccountByIdAsync(Guid accountId)
+        public async Task<Account?> GetAccountByIdAsync(Guid accountId)
         {
             var account = await _accountRepository.GetByIdAsync(accountId);
             return account;

--- a/OrangeJuiceBank/OrangeJuiceBank.Domain/Services/IAccountService.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.Domain/Services/IAccountService.cs
@@ -7,7 +7,7 @@ namespace OrangeJuiceBank.Domain.Services
         Task WithdrawAsync(Guid accountId, decimal amount);
         Task TransferAsync(Guid sourceAccountId, Guid destinationAccountId, decimal amount);
         Task CreateAccountAsync(Account account);
-        Task<Account> GetAccountByIdAsync(Guid accountId);
+        Task<Account?> GetAccountByIdAsync(Guid accountId);
         Task<IEnumerable<Account>> GetAccountsByUserIdAsync(Guid userId);
 
     }


### PR DESCRIPTION
Foi implementado o filtro por data no endpoint de extrato de transações da conta, permitindo consultar movimentações em um período específico.

Também foram realizados testes manuais e automatizados para validar o correto funcionamento da nova funcionalidade e garantir que os resultados retornados estejam de acordo com o intervalo informado.