### PR TITLE
Relatorios de investimentos e imposto

### DIFF
--- a/OrangeJuiceBank/OrangeJuiceBank.API/Controllers/ReportsController.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.API/Controllers/ReportsController.cs
@@ -1,0 +1,100 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OrangeJuiceBank.API.Models;
+using OrangeJuiceBank.Domain.Repositories;
+
+namespace OrangeJuiceBank.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class ReportsController : ControllerBase
+    {
+        private readonly IAccountRepository _accountRepository;
+        private readonly ITransactionRepository _transactionRepository;
+
+        public ReportsController(
+            IAccountRepository accountRepository,
+            ITransactionRepository transactionRepository)
+        {
+            _accountRepository = accountRepository;
+            _transactionRepository = transactionRepository;
+        }
+
+        [HttpGet("tax")]
+        public async Task<IActionResult> GetTaxReport([FromQuery] int year)
+        {
+            var userId = Guid.Parse(User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)!.Value);
+
+            var accounts = await _accountRepository.GetByUserIdAsync(userId);
+            var investmentAccounts = accounts.Where(a => a.Type == AccountType.Investimento).ToList();
+
+            var reportItems = new List<TaxReportItemResponse>();
+
+            foreach (var account in investmentAccounts)
+            {
+                var transactions = await _transactionRepository.GetByAccountIdAsync(account.Id);
+
+                var sales = transactions
+                    .Where(t => t.Type == TransactionType.VendaAtivo && t.Timestamp.Year == year)
+                    .ToList();
+
+                foreach (var sale in sales)
+                {
+                    var investment = account.Investments.FirstOrDefault(i => i.AssetId == sale.DestinationAccountId);
+                    // Como no seu modelo a venda não salva AssetId no Transaction, 
+                    // pode ser necessário ajustar ou guardar AssetId no futuro.
+
+                    reportItems.Add(new TaxReportItemResponse
+                    {
+                        AssetName = "(Ativo não identificado)",
+                        AssetType = AssetType.Acao, // ou outro tipo se tiver como identificar
+                        SaleDate = sale.Timestamp,
+                        Quantity = 0, // você não salva a quantidade na transação, considere adicionar
+                        SalePrice = sale.Amount,
+                        PurchasePrice = 0,
+                        Profit = 0,
+                        TaxRetained = 0
+                    });
+                }
+            }
+
+            return Ok(reportItems);
+        }
+
+        [HttpGet("investments")]
+        public async Task<IActionResult> GetInvestmentsSummary()
+        {
+            var userId = Guid.Parse(User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)!.Value);
+
+            var accounts = await _accountRepository.GetByUserIdAsync(userId);
+            var investmentAccounts = accounts.Where(a => a.Type == AccountType.Investimento).ToList();
+
+            var summaries = new List<InvestmentSummaryResponse>();
+
+            foreach (var account in investmentAccounts)
+            {
+                foreach (var investment in account.Investments)
+                {
+                    var currentValue = investment.Quantity * investment.Asset.CurrentPrice;
+                    var totalInvested = investment.Quantity * investment.AveragePrice;
+                    var profit = currentValue - totalInvested;
+
+                    summaries.Add(new InvestmentSummaryResponse
+                    {
+                        AssetName = investment.Asset.Name,
+                        AssetType = investment.Asset.Type,
+                        Quantity = investment.Quantity,
+                        AveragePrice = investment.AveragePrice,
+                        CurrentPrice = investment.Asset.CurrentPrice,
+                        TotalInvested = totalInvested,
+                        CurrentValue = currentValue,
+                        Profit = profit
+                    });
+                }
+            }
+
+            return Ok(summaries);
+        }
+    }
+}

--- a/OrangeJuiceBank/OrangeJuiceBank.API/Models/InvestmentSummaryResponse.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.API/Models/InvestmentSummaryResponse.cs
@@ -1,0 +1,15 @@
+﻿
+namespace OrangeJuiceBank.API.Models
+{
+    public class InvestmentSummaryResponse
+    {
+        public string AssetName { get; set; } = string.Empty;
+        public AssetType AssetType { get; set; }
+        public decimal Quantity { get; set; }
+        public decimal AveragePrice { get; set; }
+        public decimal CurrentPrice { get; set; }
+        public decimal TotalInvested { get; set; }
+        public decimal CurrentValue { get; set; }
+        public decimal Profit { get; set; }
+    }
+}

--- a/OrangeJuiceBank/OrangeJuiceBank.API/Models/TaxReportItemResponse.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.API/Models/TaxReportItemResponse.cs
@@ -1,0 +1,14 @@
+﻿namespace OrangeJuiceBank.API.Models
+{
+    public class TaxReportItemResponse
+    {
+        public string AssetName { get; set; }
+        public AssetType AssetType { get; set; }
+        public DateTime SaleDate { get; set; }
+        public decimal Quantity { get; set; }
+        public decimal SalePrice { get; set; }
+        public decimal PurchasePrice { get; set; }
+        public decimal Profit { get; set; }
+        public decimal TaxRetained { get; set; }
+    }
+}

--- a/OrangeJuiceBank/OrangeJuiceBank.Tests/ReportsControllerTests.cs
+++ b/OrangeJuiceBank/OrangeJuiceBank.Tests/ReportsControllerTests.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using OrangeJuiceBank.API.Controllers;
+using OrangeJuiceBank.API.Models;
+using OrangeJuiceBank.Domain;
+using OrangeJuiceBank.Domain.Repositories;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using Xunit;
+
+namespace OrangeJuiceBank.Tests
+{
+    public class ReportsControllerTests
+    {
+        private readonly Mock<IAccountRepository> _accountRepoMock = new();
+        private readonly Mock<ITransactionRepository> _transactionRepoMock = new();
+
+        private ReportsController CreateController(Guid userId)
+        {
+            var controller = new ReportsController(
+                _accountRepoMock.Object,
+                _transactionRepoMock.Object
+            );
+
+            var user = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, userId.ToString())
+            }));
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = user }
+            };
+
+            return controller;
+        }
+
+        [Fact]
+        public async Task GetInvestmentSummary_ShouldReturnInvestments()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+
+            var accounts = new List<Account>
+            {
+                new Account
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = userId,
+                    Type = AccountType.Investimento,
+                    Balance = 5000m,
+                    Investments = new List<Investment>
+                    {
+                        new Investment
+                        {
+                            Id = Guid.NewGuid(),
+                            Asset = new Asset
+                            {
+                                Id = Guid.NewGuid(),
+                                Name = "Ação Teste",
+                                Type = AssetType.Acao,
+                                CurrentPrice = 120m
+                            },
+                            AssetId = Guid.NewGuid(),
+                            Quantity = 10m,
+                            AveragePrice = 100m
+                        }
+                    }
+                }
+            };
+
+            _accountRepoMock.Setup(r => r.GetByUserIdAsync(userId))
+                .ReturnsAsync(accounts);
+
+            var controller = CreateController(userId);
+
+            // Act
+            var result = await controller.GetInvestmentsSummary();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var data = Assert.IsAssignableFrom<IEnumerable<InvestmentSummaryResponse>>(okResult.Value);
+
+            var item = data.First();
+            Assert.Equal("Ação Teste", item.AssetName);
+            Assert.Equal(AssetType.Acao, item.AssetType);
+            Assert.Equal(10m, item.Quantity);
+            Assert.Equal(100m, item.AveragePrice);
+            Assert.Equal(120m, item.CurrentPrice);
+            Assert.Equal(1000m, item.TotalInvested);
+            Assert.Equal(1200m, item.CurrentValue);
+            Assert.Equal(200m, item.Profit);
+        }
+    }
+}


### PR DESCRIPTION
Adiciona o endpoint que lista o resumo dos investimentos do usuário, mostrando dados como quantidade, preço médio, preço atual e lucro.
Inclui testes unitários para validar o funcionamento e garantir que as informações retornadas estejam corretas.